### PR TITLE
Add YAML prerequisite and link to YAML guide

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -31,8 +31,8 @@ Although these scripts might provide a direct means of accessing the tools, writ
 Shell scripts are not easily portable, and so researchers can easily end up spending more time maintaining the scripts than carrying out their research. 
 The aim of CWL is to reduce that barrier of usage of these tools to researchers.
 
-CWL workflows are written in a subset of YAML, with a syntax that does not restrict the amount of detail provided for a tool or workflow. 
-The execution model is explicit, all required elements of a tool's runtime environment must be specified by the CWL tool-description author. 
+CWL workflows are written in a subset of [YAML], with a syntax that does not restrict the amount of detail provided for a tool or workflow.
+The execution model is explicit, all required elements of a tool's runtime environment must be specified by the CWL tool-description author.
 On top of these basic requirements they can also add hints or requirements to the tool-description, helping to guide users (and workflow engines) on what resources are needed for a tool.
 
 The CWL standards explicitly support the use of software container technologies, helping ensure that the execution of tools is reproducible. 
@@ -60,3 +60,5 @@ The different tools necessary for this analysis are already available. In this t
 {% include links.md %}
 
 [^1]: M. R. Crusoe, S. Abeln, A. Iosup, P. Amstutz, J. Chilton, N. Tijanić, H. Ménager, S. Soiland-Reyes, B. Gavrilović, C. Goble, The CWL Community (2021): Methods Included: Standardizing Computational Reuse and Portability with the Common Workflow Language. Communication of the ACM. https://doi.org/10.1145/3486897
+
+[YAML]: http://www.commonwl.org/user_guide/yaml/

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ for the tutorial material
 > tasks on a remote machine (by `ssh` connection)
 > and in a cluster (high performance computing) environment.
 >
-> You should also be familiar with the [subset of YAML][yaml-for-cwl] used in CWL.
+> CWL is based upon YAML. At any time, if you find yourself being confused by the YAML syntax, considering reviewing this guide on the [subset of YAML][yaml-for-cwl] used in CWL.
 >
 > If you have previously written a workflow description,
 > in CWL or another langauge,

--- a/index.md
+++ b/index.md
@@ -49,6 +49,8 @@ for the tutorial material
 > tasks on a remote machine (by `ssh` connection)
 > and in a cluster (high performance computing) environment.
 >
+> You should also be familiar with the [subset of YAML][yaml-for-cwl] used in CWL.
+>
 > If you have previously written a workflow description,
 > in CWL or another langauge,
 > you may want to look instead at the [User Guide][cwl-user-guide].
@@ -129,4 +131,5 @@ After following one of these tutorials, learners will be able to:
 
 [swc]: https://software-carpentry.org/
 [swc-shell]: https://swcarpentry.github.io/shell-novice/
+[yaml-for-cwl]: https://www.commonwl.org/user_guide/yaml/
 {% include links.md %}


### PR DESCRIPTION
Fix #10.

I've deliberately not reproduced any of the YAML syntax in this lesson but instead just linked to the guide.