### PR TITLE
Docker requirements for setup process

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -300,7 +300,7 @@ cwltool --outdir rnaseq/ bio-cwl-tools/STAR/STAR-Index.cwl dm6-star-index.yaml
 {: .language-bash}
 It should take 10-15 minutes for the index to be generated.
 
-> # Docker Requirements
+> ## Docker Requirements
 > To generate the index files you will need to allocate docker at least 9Gb of RAM. 
 > This can be done through the `Preferences`->`Resources` menu.  
 >

--- a/setup.md
+++ b/setup.md
@@ -298,5 +298,19 @@ Generate the index files with `cwltool`:
 cwltool --outdir rnaseq/ bio-cwl-tools/STAR/STAR-Index.cwl dm6-star-index.yaml
 ~~~
 {: .language-bash}
+It should take 10-15 minutes for the index to be generated.
+
+> # Docker Requirements
+> To generate the index files you will need to allocate docker at least 9Gb of RAM. 
+> This can be done through the `Prefences`->`Resources` menu.  
+>
+> If you do not allocate enough RAM the tool will not crash, but the process will stick
+> on the following step:
+> ```
+> ... sorting Suffix Array chunks and saving them to disk...
+> ```
+> If this step does not finished within 10 minutes then it is likely the process has failed,
+> and should be cancelled.
+{: .callout}
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -302,14 +302,14 @@ It should take 10-15 minutes for the index to be generated.
 
 > # Docker Requirements
 > To generate the index files you will need to allocate docker at least 9Gb of RAM. 
-> This can be done through the `Prefences`->`Resources` menu.  
+> This can be done through the `Preferences`->`Resources` menu.  
 >
 > If you do not allocate enough RAM the tool will not crash, but the process will stick
 > on the following step:
 > ```
 > ... sorting Suffix Array chunks and saving them to disk...
 > ```
-> If this step does not finished within 10 minutes then it is likely the process has failed,
+> If this step does not finish within 10 minutes then it is likely the process has failed,
 > and should be cancelled.
 {: .callout}
 


### PR DESCRIPTION
Adding requirements information for the Setup process, as well as advice on what users should look for to see if their process is working or not. As noted in https://github.com/carpentries-incubator/cwl-novice-tutorial/issues/51, a minimum of 9Gb RAM allocated to docker is required to generate the index files.