### PR TITLE
Changed workflow and input file names

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -1,5 +1,5 @@
 ---
-title: "Introduction"
+title: "1. Introduction"
 teaching: 0
 exercises: 0
 questions:

--- a/_episodes/02-shell_to_cwl.md
+++ b/_episodes/02-shell_to_cwl.md
@@ -1,5 +1,5 @@
 ---
-title: "CWL and Shell Tools"
+title: "2. CWL and Shell Tools"
 teaching: 0
 exercises: 0
 questions:

--- a/_episodes/02-shell_to_cwl.md
+++ b/_episodes/02-shell_to_cwl.md
@@ -153,9 +153,9 @@ The RNA-seq data from the introduction episode will be used for the first CWL wo
 The first step of RNA-sequencing analysis is a quality control of the RNA reads using the `fastqc` tool.
 This tool is already available to use so there is no need to write a new CWL tool description.
 
-This is the workflow file (`rna_seq_workflow.cwl`).
+This is the workflow file (`rna_seq_workflow1.cwl`).
 
-__rna_seq_workflow.cwl__
+__rna_seq_workflow1.cwl__
 ~~~
 cwlVersion: v1.2
 class: Workflow
@@ -227,9 +227,9 @@ Inside `qc_html` the type of output is defined. The output of the `quality_contr
 The `outputSource` field refers to where the output is located, in this example it came from the step `quality_control` and it is called `html_file`.
 
 When you want to run this workflow, you need to provide a file with the inputs the workflow needs. This file is similar to the `hello_world.yml` file in the previous section.
-The input file is called `workflow_input.yml`
+The input file is called `workflow_input1.yml`
 
-__workflow_input.yml__
+__workflow_input1.yml__
 ~~~
 rna_reads_fruitfly:
   class: File
@@ -248,7 +248,7 @@ In this example the last line is needed to provide a format for the fastq file.
 Now you can run the workflow using the following command:
 
 ~~~
-cwltool rna_seq_workflow.cwl workflow_input.yml
+cwltool rna_seq_workflow1.cwl workflow_input1.yml
 ~~~
 {: .language-bash}
 

--- a/_episodes/03-dependency_graphs.md
+++ b/_episodes/03-dependency_graphs.md
@@ -26,7 +26,7 @@ In this episode, the workflow is extended with the next two steps of the RNA-seq
 The next two steps are triming the reads and alignment of the trimmed reads.
 We will be using the [`cutadapt`](https://bio.tools/cutadapt)  and [`STAR`](https://bio.tools/star) tools for these tasks.
 
-__rna_seq_workflow.cwl__
+__rna_seq_workflow2.cwl__
 ~~~
 cwlVersion: v1.2
 class: Workflow
@@ -102,9 +102,9 @@ To run the tool better, it needs more RAM than the default. So there is a `requi
 
 The newly added `mapping_reads` step also need an input not provided by any of our other steps, therefore an additional workflow-level input is added: a directory that contains the reference genome necessary for the mapping.
 
-This `ref_genome` is added in the `inputs` field of the workflow and in the YAML input file, `workflow_input.yml`.
+This `ref_genome` is added in the `inputs` field of the workflow and in the YAML input file, `workflow_input2.yml`.
 
-__workflow_input.yml__
+__workflow_input2.yml__
 ~~~
 rna_reads_forward:
   class: File
@@ -174,7 +174,7 @@ It is also possible to generate the graph in the command line. `cwltool` has a f
 The `--print-dot` option will print a file suitable for Graphviz `dot` program. This is the command to generate a Scalable Vector Graphic (SVG) file:
 
 ~~~
-cwltool --print-dot rna_seq_workflow.cwl | dot -Tsvg > workflow_graph.svg
+cwltool --print-dot rna_seq_workflow2.cwl | dot -Tsvg > workflow_graph.svg
 ~~~
 {: .language-bash}
 

--- a/_episodes/03-dependency_graphs.md
+++ b/_episodes/03-dependency_graphs.md
@@ -1,5 +1,5 @@
 ---
-title: "Developing Multi-Step Workflows"
+title: "3. Developing Multi-Step Workflows"
 teaching: 0
 exercises: 0
 questions:

--- a/_episodes/04-reusing_tools.md
+++ b/_episodes/04-reusing_tools.md
@@ -131,7 +131,7 @@ so the tool should be located at `bio-cwl-tools/subread/featureCounts.cwl`.
 The workflow is complete and we only need to complete the YAML input file.
 The last entry in the input file is the `annotations` file.
 
-__workflow_input.yml__
+__workflow_input2.yml__
 ~~~
 rna_reads_forward:
   class: File
@@ -153,7 +153,7 @@ gene_model:
 
 You have finished the workflow and the input file and now you can run the whole workflow.
 ~~~
-cwltool rna_seq_workflow.cwl workflow_input.yml
+cwltool rna_seq_workflow2.cwl workflow_input2.yml
 ~~~
 {: .language-bash}
 

--- a/_episodes/04-reusing_tools.md
+++ b/_episodes/04-reusing_tools.md
@@ -1,5 +1,5 @@
 ---
-title: "Resources for Reusing Tools and Scripts"
+title: "4. Resources for Reusing Tools and Scripts"
 teaching: 0
 exercises: 0
 questions:

--- a/_episodes/debug.md
+++ b/_episodes/debug.md
@@ -1,5 +1,5 @@
 ---
-title: "Debugging Workflows"
+title: "5. Debugging Workflows"
 teaching: 0
 exercises: 0
 questions:

--- a/_episodes/more_info.md
+++ b/_episodes/more_info.md
@@ -1,5 +1,5 @@
 ---
-title: "More information"
+title: "6. More information"
 ---
 
 If you want to know more about CWL script and workflows, you can look at one of these websites:


### PR DESCRIPTION
One of the notes from the CWL workshop this afternoon:

- Changed filenames so students don't need to edit their files in place
