### PR TITLE
add SNAP/docker fix for linux

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -130,6 +130,17 @@ data-toggle="tab">Linux</a></li>
        {: .language-bash}
 
       For other Linux systems, check <https://graphviz.org/download/#linux>
+> ## Extra action if you install Docker using Snap
+> [Snap](https://snapcraft.io/) is an app management system for linux - which is popular on 
+> Ubuntu and other systems. Docker is available via Snap - if you have installed it using 
+> this service you will need to take the following steps, to ensure docker will work properly.
+> ~~~
+> mkdir ~/tmp
+> export TMPDIR="~/tmp"
+> ~~~
+> {: .language-bash}
+> Each time you open a new terminal you will have to enter the `export TMPDIR="~/tmp"` command, 
+> or you can add it to your `~/.profile` or `~/.bashrc` file.
 </article>
 
 <article role="tabpanel" class="tab-pane" id="macos">

--- a/setup.md
+++ b/setup.md
@@ -141,6 +141,7 @@ data-toggle="tab">Linux</a></li>
 > {: .language-bash}
 > Each time you open a new terminal you will have to enter the `export TMPDIR="~/tmp"` command, 
 > or you can add it to your `~/.profile` or `~/.bashrc` file.
+{: .callout}
 </article>
 
 <article role="tabpanel" class="tab-pane" id="macos">

--- a/setup.md
+++ b/setup.md
@@ -130,6 +130,7 @@ data-toggle="tab">Linux</a></li>
        {: .language-bash}
 
       For other Linux systems, check <https://graphviz.org/download/#linux>
+
 > ## Extra action if you install Docker using Snap
 > [Snap](https://snapcraft.io/) is an app management system for linux - which is popular on 
 > Ubuntu and other systems. Docker is available via Snap - if you have installed it using 
@@ -142,6 +143,7 @@ data-toggle="tab">Linux</a></li>
 > Each time you open a new terminal you will have to enter the `export TMPDIR="~/tmp"` command, 
 > or you can add it to your `~/.profile` or `~/.bashrc` file.
 {: .callout}
+
 </article>
 
 <article role="tabpanel" class="tab-pane" id="macos">


### PR DESCRIPTION
Added a note about the necessity
to set TMPDIR on linux if docker is
installed via Snap.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact the CWL Team via https://www.commonwl.org/#Support.

You may delete these instructions from your comment.

</details>
